### PR TITLE
Remove groovy meta-declaration

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,7 +1,5 @@
 #!/usr/bin/env nextflow
 /*
- * vim: syntax=groovy
- * -*- mode: groovy;-*-
  *
  ======================================================================
  ViPR: Viral amplicon/enrichment analysis and intrahost variant calling


### PR DESCRIPTION
Nextflow is now correctly recognised as a proper language.